### PR TITLE
edited nba_scraper to streamline to chrome only

### DIFF
--- a/R/nba_scraper.R
+++ b/R/nba_scraper.R
@@ -2,13 +2,12 @@
 #'
 #' Scrape the tabular data from ESPN NBA website using RSelenium and returns a tibble
 #' of the data. Users can specify the seaason year and season type. User should also
-#' specify the port for Selenium driver, and the driver type. By default, the function
-#' will not write to csv until an input for "csv_path" is given.
+#' specify the port for Selenium driver. By default, the function will not write
+#' to csv until a string input for "csv_path" is given.
 #'
 #' @param season_year int from 2001 to 2019 (upper limit based on latest year)
 #' @param season_type string. Either "regular" or "postseason"
 #' @param port int with L suffix. Must not be negative.
-#' @param sel_browser string. Either "chrome" or "firefox".
 #' @param csv_path string for csv file. Defaults to NULL. If specified, must end with ".csv".
 #'
 #' @export
@@ -21,21 +20,16 @@
 #' @return A tibble of scraped ESPN NBA data
 #'
 #' @examples
-#' # Scrape regular season 2018/19 using "chrome" driver and
-#' # without saving to a csv file
-#' \dontrun{
-#' #' nba_scraper(2018, season_type = "regular",
-#'                port=4445L, sel_browser = "chrome")
-#' }
+#' # Scrape regular season 2018/19 without saving to a csv file
+#' nba_2018 <- nba_scraper(2018, season_type = "regular", port=4445L)
 #'
-#' # Scrape playoffs season 2017/18 using "firefox" driver while
-#' # saving to a local csv file.
-#' \dontrun{
-#' nba_scraper(2017, season_type = "postseason",
-#'             port=4445L, sel_browser = "firefox",
-#'             csv_path = "nba_2017_playoffs.csv")
-#' }
-nba_scraper <- function(season_year = 2018, season_type = "regular", port=4445L, sel_browser = "chrome", csv_path = NULL) {
+#'
+#' # Scrape playoffs season 2017/18 while saving to a local csv file.
+#' nba_2017 <- nba_scraper(2017, season_type = "postseason",
+#'                         port=4445L,
+#'                         csv_path = "nba_2017_playoffs.csv")
+#'
+nba_scraper <- function(season_year = 2018, season_type = "regular", port=4445L, csv_path = NULL) {
 
   # Check season_year is integer
   if ((season_year - round(season_year)) != 0){
@@ -57,11 +51,6 @@ nba_scraper <- function(season_year = 2018, season_type = "regular", port=4445L,
     stop("'port' must be a positive integer ending with L suffix (eg 4445L)")
   }
 
-  # Check sel_browser must be either "chrome" or "firefox"
-  if ((sel_browser != "chrome") & (sel_browser != "firefox")) {
-    stop("'sel_browser' must be either 'chrome' or 'firefox'")
-  }
-
   # Check csv_path does not end with csv
   if (!is.null(csv_path)) {
     if (substr(csv_path, nchar(csv_path)-3, nchar(csv_path)) != ".csv"){
@@ -78,7 +67,7 @@ nba_scraper <- function(season_year = 2018, season_type = "regular", port=4445L,
   remDr <- RSelenium::remoteDriver(
     remoteServerAddr = "localhost",
     port = port,
-    browserName = sel_browser
+    browserName = "chrome"
   )
 
   # Print message

--- a/README.Rmd
+++ b/README.Rmd
@@ -48,7 +48,7 @@ https://www.espn.com/nba/stats/player/_/season/2019/seasontype/2
 
 The `rsketball::nba_scraper` is based on Selenium (or specifically RSelenium) which enables automated web browsing through "drivers". __To use it, please ensure that `Docker` is installed.__
 
-For installation instructions, please follow the [guide to Docker installation based on your OS type](https://ubc-mds.github.io/resources_pages/installation_instructions/). Docker will be used to pull relevant images that when executed as containers, will serve as the "drivers" for Selenium. 
+For installation instructions, please follow the [guide to Docker installation based on your OS type](https://ubc-mds.github.io/resources_pages/installation_instructions/). Docker will be used to pull the relevant Chromedriver image that when executed as containers, will serve as the "driver" for Selenium. 
 
 The following steps are required only for the `nba_scraper` function. If you already have the scraped data file and wish to use the other functions (`nba_boxplot`, `nba_rank`, `nbastats`), there is no need to proceed with these steps.
 
@@ -76,11 +76,10 @@ Now that the container is running with the allocated memory and assigned port, w
 
 ```R
 library(rsketball)
-# Scrape postseason season 2017/18 using "chrome" driver while saving to a local csv file.
+# Scrape postseason season 2017/18 while saving to a local csv file.
 nba_2017_playoffs <- nba_scraper(season_year = 2017, 
                                  season_type = "postseason",
-                                 port=4445L, 
-                                 sel_browser = "chrome",
+                                 port=4445L,
                                  csv_path = "nba_2017_playoffs.csv")
 ```
 If everything was executed as intended, you should obtain a csv file called "nba_2017_playoffs.csv" containing the scraped data, and a tibble in your R environment named "nba_2017_playoffs". With the tibble, you can use the other `rsketball` functions for your analysis.

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ use it, please ensure that `Docker` is installed.**
 For installation instructions, please follow the [guide to Docker
 installation based on your OS
 type](https://ubc-mds.github.io/resources_pages/installation_instructions/).
-Docker will be used to pull relevant images that when executed as
-containers, will serve as the “drivers” for Selenium.
+Docker will be used to pull the relevant Chromedriver image that when
+executed as containers, will serve as the “driver” for Selenium.
 
 The following steps are required only for the `nba_scraper` function. If
 you already have the scraped data file and wish to use the other
@@ -95,11 +95,10 @@ port, we can proceed with testing
 
 ``` r
 library(rsketball)
-# Scrape postseason season 2017/18 using "chrome" driver while saving to a local csv file.
+# Scrape postseason season 2017/18 while saving to a local csv file.
 nba_2017_playoffs <- nba_scraper(season_year = 2017, 
                                  season_type = "postseason",
-                                 port=4445L, 
-                                 sel_browser = "chrome",
+                                 port=4445L,
                                  csv_path = "nba_2017_playoffs.csv")
 ```
 

--- a/man/nba_scraper.Rd
+++ b/man/nba_scraper.Rd
@@ -8,7 +8,6 @@ nba_scraper(
   season_year = 2018,
   season_type = "regular",
   port = 4445L,
-  sel_browser = "chrome",
   csv_path = NULL
 )
 }
@@ -19,8 +18,6 @@ nba_scraper(
 
 \item{port}{int with L suffix. Must not be negative.}
 
-\item{sel_browser}{string. Either "chrome" or "firefox".}
-
 \item{csv_path}{string for csv file. Defaults to NULL. If specified, must end with ".csv".}
 }
 \value{
@@ -29,22 +26,17 @@ A tibble of scraped ESPN NBA data
 \description{
 Scrape the tabular data from ESPN NBA website using RSelenium and returns a tibble
 of the data. Users can specify the seaason year and season type. User should also
-specify the port for Selenium driver, and the driver type. By default, the function
-will not write to csv until an input for "csv_path" is given.
+specify the port for Selenium driver. By default, the function will not write
+to csv until a string input for "csv_path" is given.
 }
 \examples{
-# Scrape regular season 2018/19 using "chrome" driver and
-# without saving to a csv file
-\dontrun{
-#' nba_scraper(2018, season_type = "regular",
-               port=4445L, sel_browser = "chrome")
-}
+# Scrape regular season 2018/19 without saving to a csv file
+nba_2018 <- nba_scraper(2018, season_type = "regular", port=4445L)
 
-# Scrape playoffs season 2017/18 using "firefox" driver while
-# saving to a local csv file.
-\dontrun{
-nba_scraper(2017, season_type = "postseason",
-            port=4445L, sel_browser = "firefox",
-            csv_path = "nba_2017_playoffs.csv")
-}
+
+# Scrape playoffs season 2017/18 while saving to a local csv file.
+nba_2017 <- nba_scraper(2017, season_type = "postseason",
+                        port=4445L,
+                        csv_path = "nba_2017_playoffs.csv")
+
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,11 +1,22 @@
 # Testing `rsketball`
 
-`rsketball` has a scraper function `nba_scraper` that utilises the library `RSelenium`. Thus, to perform the necessary tests, it is essential to run a Docker image containing the standalone chrome browser driver.
+`rsketball` has a scraper function `nba_scraper` that utilises the library `RSelenium`. Thus, to perform the necessary tests, it is essential to run a Docker image containing the standalone chrome driver.
+
+Pull docker image with the following code in Terminal. We will stick to Chrome since it seems compatible with Windows while Firefox is not.
+
+```sh
+docker pull selenium/standalone-chrome
+```
+
+We need to set up the Docker container default port 4444 to our computer host port 4445. Keep this port number as inputs for the `nba_scraper` function. We will also allocate the virtual memory of the container to 2Gb for it to scrape effectively. 
+
+Run the following code in Terminal:
 
 ```sh
 docker run -d -p 4445:4444 --shm-size 2g selenium/standalone-chrome
 ```
-Note the arguments to map the computer port 4445 to the Docker driver's port 4444. 
+
+Note the arguments to map the computer port 4445 to the Docker driver's port 4444.
 
 Once that is set up, you can proceed to perform testing for `rsketball` by running the following code in the project repo using the R console.
 

--- a/tests/testthat/test-nba_scraper.R
+++ b/tests/testthat/test-nba_scraper.R
@@ -14,10 +14,10 @@
 #' test_nba_scraper()
 test_nba_scraper <- function() {
   # Test season_year input that is wrong format
-  test_that("season_year below value of 2001 will throw an error", {
-    expect_error(nba_scraper(season_year = 1999.9,
+  test_that("season_year that is not an integer will throw an error", {
+    expect_error(nba_scraper(season_year = 2003.5,
                              season_type = "postseason",
-                             port=4445L, sel_browser = "firefox",
+                             port=4445L,
                              csv_path = NULL))
   })
 
@@ -25,7 +25,7 @@ test_nba_scraper <- function() {
   test_that("season_year below value of 2001 will throw an error", {
     expect_error(nba_scraper(season_year = 1999,
                              season_type = "postseason",
-                             port=4445L, sel_browser = "firefox",
+                             port=4445L,
                              csv_path = NULL))
   })
 
@@ -33,7 +33,7 @@ test_nba_scraper <- function() {
   test_that("season_type that is not 'regular' or 'postseason' will give an error", {
     expect_error(nba_scraper(season_year = 2018,
                              season_type = "hello",
-                             port=4445L, sel_browser = "firefox",
+                             port=4445L,
                              csv_path = NULL))
   })
 
@@ -41,7 +41,6 @@ test_nba_scraper <- function() {
   test_that("port input without L suffix will give an error", {
     expect_error(nba_scraper(season_year = 2018, season_type = "regular",
                              port=4445,
-                             sel_browser = "firefox",
                              csv_path = "nba_2017_playoffs.csv"))
   })
 
@@ -49,15 +48,6 @@ test_nba_scraper <- function() {
   test_that("port input of a negative number will give an error", {
     expect_error(nba_scraper(season_year = 2018, season_type = "regular",
                              port=-4445L,
-                             sel_browser = "firefox",
-                             csv_path = "nba_2017_playoffs.csv"))
-  })
-
-  #* Test selenium browser choice input
-  test_that("sel_browser input that is not 'chrome' or 'firefox' will give error", {
-    expect_error(nba_scraper(season_year = 2018, season_type = "regular",
-                             port=4445L,
-                             sel_browser = "hello",
                              csv_path = "nba_2017_playoffs.csv"))
   })
 
@@ -65,14 +55,13 @@ test_nba_scraper <- function() {
   test_that("csv_path string input that does not end in '.csv' will give an error", {
     expect_error(nba_scraper(season_year = 2018,
                              season_type = "regular",
-                             port=4445L, sel_browser = "firefox",
+                             port=4445L,
                              csv_path = "nba_2017_playoffs"))
   })
 
   # Run scraper without storing output csv file
   nba_2017 <- nba_scraper(season_year = 2017, season_type = "postseason",
-                          port=4445L,
-                          sel_browser = "chrome")
+                          port=4445L)
 
   # Test that completed scraping returns a dataframe
   test_that("Function does not return a data frame upon completion of scraping", {
@@ -82,7 +71,6 @@ test_nba_scraper <- function() {
   # Run scraper and store output as nba_2018 tibble
   nba_2018 <- nba_scraper(season_year = 2018, season_type = "postseason",
                           port=4445L,
-                          sel_browser = "chrome",
                           csv_path = "nba_2018_playoffs.csv")
 
   # Read in csv as tibble for testing


### PR DESCRIPTION
- Edited documentation, testing markdown, nba_scraper function, test_nba_scraper function to remove "firefox" use. This is to streamline all to "chrome" driver use with Docker image.